### PR TITLE
docs: explain Go symbol hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@
     The `GoSymbolHash` algorithm is analogous to the algorithm described for `ImportHash` with the exception that Go's static symbols are used in place of the dynamic import symbols used by `ImportHash`.
 
     The list of symbols referenced by the executable is obtained and the MD5 hash of the ordered list of symbols, separated by commas, is calculated.
+    The order of the symbols is as exists in the executable and returned by the Go standard library debug packages.
     The fully qualified import path of each symbol is included and while symbols used by `ImportHash` are canonicalised to lowercase, `GoSymbolHash` retains the case of the original symbol. `GoSymbolHash` may be calculated including or excluding standard library imports.
 - `Sections`: provide section size and entropy statistics for an executable.

--- a/README.md
+++ b/README.md
@@ -5,4 +5,9 @@
 - `Stripped`: scan files that may be executable and report whether they are a Go executable that has had its symbols stripped.
 - `ImportHash`: calculate the [imphash](https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html) of an executable with dynamic imports.
 - `GoSymbolHash`: calculate an imphash analogue for Go executables compiled by the gc-compiler.
-- `Sections`: provide section size statistics for an executable.
+
+    The `GoSymbolHash` algorithm is analogous to the algorithm described for `ImportHash` with the exception that Go's static symbols are used in place of the dynamic import symbols used by `ImportHash`.
+
+    The list of symbols referenced by the executable is obtained and the MD5 hash of the ordered list of symbols, separated by commas, is calculated.
+    The fully qualified import path of each symbol is included and while symbols used by `ImportHash` are canonicalised to lowercase, `GoSymbolHash` retains the case of the original symbol. `GoSymbolHash` may be calculated including or excluding standard library imports.
+- `Sections`: provide section size and entropy statistics for an executable.

--- a/toutoumomoma.go
+++ b/toutoumomoma.go
@@ -155,6 +155,10 @@ func (f *File) Stripped() (sneaky bool, err error) {
 // Darwin imports are the list of symbols without a library prefix and is equivalent
 // to the Anomali SymHash https://www.anomali.com/blog/symhash.
 //
+// The algorithm obtains the list of imported function names and converts them to all
+// lowercase. Any file extension is removed and then the MD5 hash of the ordered list of
+// symbols, separated by commas, is calculated.
+//
 // Darwin:
 //  ___error
 //  __exit
@@ -202,8 +206,15 @@ func (f *File) ImportHash() (hash []byte, imports []string, err error) {
 // from the Go standard library are included, otherwise only third-party symbols
 // are considered.
 //
-// If the file at is an executable, but not a gc-compiled Go executable,
-// ErrNotGoExecutable will be returned.
+// The algorithm is analogous to the algorithm described for ImportHash with the exception
+// that Go's static symbols are used in place of the dynamic import symbols used by the
+// ImportHash. The list of symbols referenced by the executable is obtained and the MD5 hash
+// of the ordered list of symbols, separated by commas, is calculated. The fully qualified
+// import path of each symbol is included and while symbols used by ImportHash are
+// canonicalised to lowercase, GoSymbolHash retains the case of the original symbol.
+//
+// If the file is an executable, but not a gc-compiled Go executable, ErrNotGoExecutable
+// will be returned.
 func (f *File) GoSymbolHash(stdlib bool) (hash []byte, imports []string, err error) {
 	ok, err := f.isGoExecutable()
 	if !ok || err != nil {

--- a/toutoumomoma.go
+++ b/toutoumomoma.go
@@ -209,9 +209,11 @@ func (f *File) ImportHash() (hash []byte, imports []string, err error) {
 // The algorithm is analogous to the algorithm described for ImportHash with the exception
 // that Go's static symbols are used in place of the dynamic import symbols used by the
 // ImportHash. The list of symbols referenced by the executable is obtained and the MD5 hash
-// of the ordered list of symbols, separated by commas, is calculated. The fully qualified
-// import path of each symbol is included and while symbols used by ImportHash are
-// canonicalised to lowercase, GoSymbolHash retains the case of the original symbol.
+// of the ordered list of symbols, separated by commas, is calculated. The order of the
+// symbols is as exists in the executable and returned by the standard library debug packages
+// The fully qualified import path of each symbol is included and while symbols used by
+// ImportHash are canonicalised to lowercase, GoSymbolHash retains the case of the original
+// symbol.
 //
 // If the file is an executable, but not a gc-compiled Go executable, ErrNotGoExecutable
 // will be returned.


### PR DESCRIPTION
Put an explicit description of the Go symbol hash algorithm in the godoc and in the README.

For elastic/ecs#2083

Please take a look.